### PR TITLE
feat: 添加修改当前模型服装功能

### DIFF
--- a/packages/oh-my-live2d/src/config/config.ts
+++ b/packages/oh-my-live2d/src/config/config.ts
@@ -95,6 +95,14 @@ export const DEFAULT_OPTIONS: DefaultOptions = {
         }
       },
       {
+        id: 'SwitchModelClothes',
+        icon: 'icon-switch',
+        title: '切换衣服',
+        onClick(oml2d): void {
+          void oml2d.loadNextModelClothes();
+        }
+      },
+      {
         id: 'SwitchModel',
         icon: 'icon-switch',
         title: '切换模型',

--- a/packages/oh-my-live2d/src/modules/load-oml2d.ts
+++ b/packages/oh-my-live2d/src/modules/load-oml2d.ts
@@ -68,9 +68,17 @@ export class LoadOhMyLive2D {
   /**
    * 加载指定模型
    * @param modelIndex 指定模型的索引值
+   * @param modelClothesIndex 指定模型的衣服索引值, 该参数仅在传入的指定模型的 path 是 string[] 时生效
    */
-  async loadSpecificModel(modelIndex: number): Promise<void> {
-    await this.oml2d?.loadSpecificModel(modelIndex);
+  async loadSpecificModel(modelIndex: number, modelClothesIndex?: number): Promise<void> {
+    await this.oml2d?.loadSpecificModel(modelIndex, modelClothesIndex);
+  }
+
+  /**
+   * 加载模型的下一个衣服, 即切换同个角色的不同模型
+   */
+  async loadNextModelClothes(): Promise<void> {
+    await this.oml2d?.loadNextModelClothes();
   }
 
   /**

--- a/packages/oh-my-live2d/src/modules/models.ts
+++ b/packages/oh-my-live2d/src/modules/models.ts
@@ -9,7 +9,8 @@ import { getWindowSizeType } from '../utils/index.js';
 
 export class Models {
   model?: Live2DModel<InternalModel>; // 当前模型实例
-  private currentModelIndex = 0;
+  private currentModelIndex: number = 0;
+  private currentClothesIndex: number = 0;
   private hitAreaFrames: HitAreaFrames;
 
   constructor(
@@ -23,8 +24,16 @@ export class Models {
   get modelIndex(): number {
     return this.currentModelIndex;
   }
+
   set modelIndex(index: number) {
     this.currentModelIndex = index;
+  }
+
+  get modelClothesIndex(): number {
+    return this.currentClothesIndex;
+  }
+  set modelClothesIndex(index: number) {
+    this.currentClothesIndex = index;
   }
 
   get currentModelOptions(): ModelOptions {
@@ -35,7 +44,13 @@ export class Models {
     return new Promise((resolve, reject) => {
       this.events.emit('load', 'loading');
 
-      this.model = this.PixiLive2dDisplay.Live2DModel.fromSync(this.currentModelOptions.path, {
+      let modelPath = this.currentModelOptions.path;
+
+      if (Array.isArray(modelPath)) {
+        modelPath = this.currentModelOptions.path[this.modelClothesIndex];
+      }
+
+      this.model = this.PixiLive2dDisplay.Live2DModel.fromSync(modelPath, {
         motionPreload: (this.currentModelOptions.motionPreloadStrategy as MotionPreloadStrategy) || MotionPreloadStrategy.IDLE,
         onError: () => {
           this.events.emit('load', 'fail');

--- a/packages/oh-my-live2d/src/modules/store.ts
+++ b/packages/oh-my-live2d/src/modules/store.ts
@@ -8,31 +8,33 @@ export class Store {
     localStorage.setItem('OML2D_MODEL_INFO', finalValue);
   }
 
-  getModuleInfo(modelOptions: ModelOptions[]): StoreModelInfo {
-    const key = this.getModelDataKey(modelOptions);
-
-    const value = JSON.parse(localStorage.getItem('OML2D_MODEL_INFO') as string) as StoreModelInfo;
-
-    if (value?.key === key) {
-      return value;
-    }
+  setModelIndex(index: number): void {
+    localStorage.setItem('OML2D_MODEL_INDEX', index.toString());
   }
 
-  getModelDataKey(modelOptions: ModelOptions[]): string {
-    const keys = modelOptions?.map((item: ModelOptions): string => {
-      return item.path;
-    });
-
-    return keys.join();
+  settModelClothesIndex(index: number): void {
+    localStorage.setItem('OML2D_MODEL_CLOTHES_INDEX', index.toString());
   }
 
-  updateModelInfo(modelOptions: ModelOptions[], currentIndex: number): void {
-    const key = this.getModelDataKey(modelOptions);
-
-    this.setModelInfo({ key, currentIndex });
+  getModelClothesIndex(): number {
+    return Number(localStorage.getItem('OML2D_MODEL_CLOTHES_INDEX'));
   }
 
-  getModelCurrentIndex(modelOptions: ModelOptions[]): number {
-    return this.getModuleInfo(modelOptions)?.currentIndex || 0;
+  getModelIndex(): number {
+    return Number(localStorage.getItem('OML2D_MODEL_INDEX'));
+  }
+
+  updateModelInfo(modelOptions: ModelOptions[]): void {
+    const paths = modelOptions?.map((item: ModelOptions): string | string[] => item.path);
+
+    this.setModelInfo(paths);
+  }
+
+  updateModelCurrentIndex(index: number): void {
+    this.setModelIndex(index);
+  }
+
+  updateModelCurrentClothesIndex(index: number): void {
+    this.settModelClothesIndex(index);
   }
 }

--- a/packages/oh-my-live2d/src/types/common.ts
+++ b/packages/oh-my-live2d/src/types/common.ts
@@ -45,7 +45,7 @@ export type LoadOml2dSDK = (
 }>;
 export type OML2D = Omit<OhMyLive2D, 'unMount' | 'initialize'>;
 
-export type StoreModelInfo = { key: string; currentIndex: number } | undefined;
+export type StoreModelInfo = (string | string[])[];
 
 export type Item = {
   id: string;

--- a/packages/oh-my-live2d/src/types/model.ts
+++ b/packages/oh-my-live2d/src/types/model.ts
@@ -15,7 +15,7 @@ export interface ModelOptions {
   /**
    * 模型的 json 文件 url 地址, 必填项
    */
-  path: string;
+  path: string | string[];
   /**
    * 模型的缩放比例
    * @default 0.1


### PR DESCRIPTION
1. 将模型的属性path由 string 更改为 string | string[] 类型。并实现 loadNextModelClothes 功能。
2. 由于需要保存 modelClothesIndex ，以前的本地存储设置不适合，因此更改相关设置。OML2D_MODEL_INFO：模型path数组；OML2D_MODEL_INDEX：当前模型索引；OML2D_MODEL_CLOTHES_INDEX：当前模型衣服索引