### PR TITLE
fix: live2D model not displaying when switching pages in instant load mode

### DIFF
--- a/packages/oh-my-live2d/src/config/style.ts
+++ b/packages/oh-my-live2d/src/config/style.ts
@@ -153,7 +153,7 @@ export const STAGE_DEFAULT_STYLE: CommonStyleType = {
   right: 'auto',
   bottom: 0,
   zIndex: '9997',
-  transform: 'translateY(130%)'
+  transform: 'translateY(0%)'
 };
 
 export const TIPS_DEFAULT_STYLE: CommonStyleType = {


### PR DESCRIPTION
fix #76 

经测试，问题源于以下 CSS 动画未正确加载：

```css
@keyframes oml2d-stage-slide-in {
  from {
    transform: translateY(130%);
  }
  to {
    transform: translateY(0%);
  }
}
```

将模型默认的 `translateY` 更改为 `0%` 能够解决此问题。不过，目前不确定这个调整是否会引发其他显示问题