### PR TITLE
fix(widget): 修复 Tips 组件空消息数组仍触发提示框的问题

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -131,7 +131,7 @@ export function createWidget(options: WidgetOptions): Widget {
   }
 
   function startTipsLoop() {
-    if (!currentModelTipsData)
+    if (!currentModelTipsData || currentModelTipsData.messages.length === 0)
       return;
     stopTipsLoop();
     tipsTimer = setInterval(() => {
@@ -141,7 +141,7 @@ export function createWidget(options: WidgetOptions): Widget {
   }
 
   function launchTips() {
-    if (!currentModelTipsData)
+    if (!currentModelTipsData || currentModelTipsData.welcomeMessages.length === 0)
       return;
     const msgs = currentModelTipsData.welcomeMessages;
     welcomeTimer = setTimeout(() => {


### PR DESCRIPTION
Fix #98 
有时我们只想要开屏\轮询提示，而不想要另一种提示。  
- 修复了当轮询提示为空时还会弹出提示框的问题。
- 当 welcomeMessages 或 messages 设置为空数组时，不再触发开屏提示和轮询提示